### PR TITLE
group,messageコントローラーでアクションを定義

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,2 +1,17 @@
 class GroupsController < ApplicationController
+  def new
+
+  end
+
+  def create
+
+  end
+
+  def edit
+
+  end
+
+  def update
+
+  end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,4 +1,8 @@
 class MessagesController < ApplicationController
   def index
   end
+
+  def create
+  end
+
 end


### PR DESCRIPTION
# WHAT
group,messageコントローラーでアクションを定義

# WHY
必須機能であるため。

アクションの中身は定義していない。